### PR TITLE
Properties file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ name = "product-config"
 version = "0.1.0-nightly"
 
 [dependencies]
+java-properties = "1.3"
 regex = "1.5"
 semver = "0.11"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub mod error;
 pub mod reader;
 pub mod ser;
 pub mod types;
+pub mod writer;
+
 mod util;
 mod validation;
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -4,8 +4,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum PropertiesWriterError {
-    #[error("Error creating properties file")]
-    PropertiesError(#[from] java_properties::PropertiesError),
+    #[error("Error creating properties file: {0}")]
+    PropertiesError(String),
 
     #[error("Error converting properties file byte array to UTF-8")]
     FromUtf8Error(#[from] std::string::FromUtf8Error),
@@ -15,6 +15,7 @@ pub fn create_properties_file(
     properties: &HashMap<String, String>,
 ) -> Result<String, PropertiesWriterError> {
     let mut output = Vec::new();
-    write(&mut output, &properties)?;
+    write(&mut output, &properties)
+        .map_err(|err| PropertiesWriterError::PropertiesError(err.to_string()))?;
     Ok(String::from_utf8(output)?)
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -2,7 +2,7 @@ use java_properties::write;
 use std::collections::HashMap;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum PropertiesWriterError {
     #[error("Error creating properties file: {0}")]
     PropertiesError(String),
@@ -11,11 +11,76 @@ pub enum PropertiesWriterError {
     FromUtf8Error(#[from] std::string::FromUtf8Error),
 }
 
-pub fn create_properties_file(
+/// Creates a common Java properties file string in the format:
+/// property_1=value_1\n
+/// property_2=value_2\n
+///
+/// The behavior is based on https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html
+/// and is adapted to "java.util.Properties" if ambiguous or incomplete.
+pub fn create_java_properties_file(
     properties: &HashMap<String, String>,
 ) -> Result<String, PropertiesWriterError> {
     let mut output = Vec::new();
     write(&mut output, &properties)
         .map_err(|err| PropertiesWriterError::PropertiesError(err.to_string()))?;
     Ok(String::from_utf8(output)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::writer::{create_java_properties_file, PropertiesWriterError};
+    use std::collections::HashMap;
+
+    const PROPERTY_1: &str = "property";
+    const PROPERTY_2: &str = "property2";
+    const VALUE_OK: &str = "abc";
+    const VALUE_OK_2: &str = "some_text!()";
+    const VALUE_OK_2_ESCAPED: &str = "some_text\\!()";
+    const VALUE_URL: &str = "file://this/location/file.abc";
+    const VALUE_URL_ESCAPED: &str = "file\\://this/location/file.abc";
+    const UTF8_ERROR: &str = "æææ";
+
+    #[test]
+    fn test_writer_ok() -> Result<(), PropertiesWriterError> {
+        let mut map = HashMap::new();
+        map.insert(PROPERTY_1.to_string(), VALUE_OK.to_string());
+        map.insert(PROPERTY_2.to_string(), VALUE_OK_2.to_string());
+
+        let result = create_java_properties_file(&map)?;
+
+        map.insert(PROPERTY_2.to_string(), VALUE_OK_2_ESCAPED.to_string());
+        assert_eq!(result, calculate_result(&map));
+        Ok(())
+    }
+
+    #[test]
+    fn test_writer_escape() -> Result<(), PropertiesWriterError> {
+        let mut map = HashMap::new();
+        map.insert(PROPERTY_1.to_string(), VALUE_URL.to_string());
+
+        let result = create_java_properties_file(&map)?;
+
+        map.insert(PROPERTY_1.to_string(), VALUE_URL_ESCAPED.to_string());
+        assert_eq!(result, calculate_result(&map));
+        Ok(())
+    }
+
+    #[test]
+    fn test_writer_no_utf8() {
+        let mut map = HashMap::new();
+        map.insert(PROPERTY_1.to_string(), UTF8_ERROR.to_string());
+
+        let result = create_java_properties_file(&map);
+        assert!(result.is_err());
+    }
+
+    fn calculate_result(properties: &HashMap<String, String>) -> String {
+        let mut result = String::new();
+
+        for (key, value) in properties {
+            result.push_str(&format!("{}={}\n", key, value));
+        }
+
+        result
+    }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,20 @@
+use java_properties::write;
+use std::collections::HashMap;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum PropertiesWriterError {
+    #[error("Error creating properties file")]
+    PropertiesError(#[from] java_properties::PropertiesError),
+
+    #[error("Error converting properties file byte array to UTF-8")]
+    FromUtf8Error(#[from] std::string::FromUtf8Error),
+}
+
+pub fn create_properties_file(
+    properties: &HashMap<String, String>,
+) -> Result<String, PropertiesWriterError> {
+    let mut output = Vec::new();
+    write(&mut output, &properties)?;
+    Ok(String::from_utf8(output)?)
+}


### PR DESCRIPTION
Added a method to properly create java properties in the form:
`key=value\n`

Checks for UTF-8 compatibility and escapes characters like ":", "!" etc.
