### PR TITLE
Fixed a bug where Cli and Env properties were filtered out if they we…

### DIFF
--- a/data/test_property_spec.json
+++ b/data/test_property_spec.json
@@ -430,5 +430,60 @@
         "value": "true"
       }
     ]
+  },
+  {
+    "property_names": [
+      {
+        "name": "start-foreground",
+        "kind": {
+          "type": "cli"
+        }
+      }
+    ],
+    "roles": [
+      {
+        "name": "role_1",
+        "required": true
+      },
+      {
+        "name": "role_2",
+        "required": false
+      }
+    ],
+    "datatype": {
+      "type": "string"
+    },
+    "as_of_version": "0.5.0"
+  },
+  {
+    "property_names": [
+      {
+        "name": "some_cli_port",
+        "kind": {
+          "type": "cli"
+        }
+      }
+    ],
+    "datatype": {
+      "type": "string",
+      "unit": "port"
+    },
+    "recommended_values": [
+      {
+        "from_version": "0.5.0",
+        "value": "8080"
+      }
+    ],
+    "roles": [
+      {
+        "name": "role_1",
+        "required": true
+      },
+      {
+        "name": "role_2",
+        "required": false
+      }
+    ],
+    "as_of_version": "0.5.0"
   }
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,8 @@ mod tests {
     //const ENV_SECURITY_PASSWORD: &str = "ENV_SECURITY_PASSWORD";
     const ENV_SSL_ENABLED: &str = "ENV_SSL_ENABLED";
     const ENV_SSL_CERTIFICATE_PATH: &str = "ENV_SSL_CERTIFICATE_PATH";
+    const CLI_START_FOREGROUND: &str = "start-foreground";
+    const CLI_SOME_PORT: &str = "some_cli_port";
 
     const ROLE_1: &str = "role_1";
     const VERSION_0_5_0: &str = "0.5.0";
@@ -307,12 +309,37 @@ mod tests {
 
         let result = config.get(version, kind, role, &user_data).unwrap();
 
-        println!("Size: {}", result.len());
-        for x in &result {
-            println!("{:?}", x)
-        }
-
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_product_get_kind_cli_role_1() {
+        let config = ProductConfigSpec::new(ConfigJsonReader::new(
+            "data/test_config_spec.json",
+            "data/test_property_spec.json",
+        ))
+        .unwrap();
+
+        let result = config
+            .get(
+                VERSION_0_5_0,
+                &PropertyNameKind::Cli,
+                Some("role_1"),
+                &HashMap::new(),
+            )
+            .unwrap();
+
+        let mut expected = HashMap::new();
+        expected.insert(
+            CLI_SOME_PORT.to_string(),
+            PropertyValidationResult::RecommendedDefault("8080".to_string()),
+        );
+        expected.insert(
+            CLI_START_FOREGROUND.to_string(),
+            PropertyValidationResult::Valid("".to_string()),
+        );
+
+        assert_eq!(result, expected)
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,7 +7,7 @@ use semver::Version;
 use std::collections::HashMap;
 
 /// Automatically retrieve and validate config properties from the property spec that:
-/// - match the provided kind (e.g. Conf(my.config))
+/// - match the provided kind (e.g. File(my.config))
 /// - match the role and are required
 /// - are available for the current product version
 /// - have dependencies with a provided value or property that has recommended value

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 /// - match the provided kind (e.g. Conf(my.config))
 /// - match the role and are required
 /// - are available for the current product version
-/// - have dependencies dependency with a provided value or property that has recommended value
+/// - have dependencies with a provided value or property that has recommended value
 ///
 /// # Arguments
 ///
@@ -66,6 +66,10 @@ pub(crate) fn get_matching_properties(
 
                             properties.extend(dependencies);
                         }
+                    }
+                    // no recommended values: Cli or Env single parameter
+                    else if kind == &PropertyNameKind::Cli || kind == &PropertyNameKind::Env {
+                        properties.insert(property_name.name.clone(), "".to_string());
                     }
                 }
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,10 +7,10 @@ use semver::Version;
 use std::collections::HashMap;
 
 /// Automatically retrieve and validate config properties from the property spec that:
-/// - match the provided kind (e.g. Conf(my.config))
+/// - match the provided kind (e.g. File(my.config))
 /// - match the role and are required
 /// - are available for the current product version
-/// - have dependencies with a provided value or property that has recommended value
+/// - have dependencies with a provided value or property that has a recommended value
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
…re meant to be single parameter flags instead of key -> value and therefore did not have a recommended value set.