### PR TITLE
Added cargo deny action to run on PR.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Description
+
+## Review Checklist
+- [ ] Code contains useful comments
+- [ ] (Integration-)Test cases added (or not applicable)
+- [ ] Documentation added (or not applicable)
+- [ ] Changelog updated (or not applicable)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,11 +74,21 @@ jobs:
         if: ${{ !steps.check_permissions.outputs.has-permission }}
         run: cargo clippy --all-targets -- -D warnings
 
-  security_audit:
-    name: Run security audit
+  cargo-deny:
+    name: Run cargo deny
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions-rs/audit-check@v1.2.0
+      - uses: actions/checkout@v2
+      - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          command: check ${{ matrix.checks }}
+

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,50 @@
+[licenses]
+
+confidence-threshold = 1.0
+copyleft = "deny"
+
+unlicensed = "deny"
+
+# List of explictly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "LicenseRef-ring",
+    "LicenseRef-webpki",
+    "MIT",
+    "Zlib"
+]
+
+deny = [
+    "AGPL-3.0"
+]
+
+exceptions = [
+    { name = "stackable-opa-crd", allow = ["OSL-3.0"] },
+    { name = "stackable-zookeeper-crd", allow = ["OSL-3.0"] },
+    { name = "stackable-kafka-crd", allow = ["OSL-3.0"] },
+    { name = "stackable-kafka-operator-server", allow = ["OSL-3.0"] },
+    { name = "stackable-kafka-operator", allow = ["OSL-3.0"] },
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "LicenseRef-ring"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "LicenseRef-webpki"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
+
+[sources.allow-org]
+github = ["stackabletech"]

--- a/deny.toml
+++ b/deny.toml
@@ -24,14 +24,6 @@ deny = [
     "AGPL-3.0"
 ]
 
-exceptions = [
-    { name = "stackable-opa-crd", allow = ["OSL-3.0"] },
-    { name = "stackable-zookeeper-crd", allow = ["OSL-3.0"] },
-    { name = "stackable-kafka-crd", allow = ["OSL-3.0"] },
-    { name = "stackable-kafka-operator-server", allow = ["OSL-3.0"] },
-    { name = "stackable-kafka-operator", allow = ["OSL-3.0"] },
-]
-
 [[licenses.clarify]]
 name = "ring"
 expression = "LicenseRef-ring"


### PR DESCRIPTION
Currently we run cargo-audit on pull requests as well as once per day.

This only checks for security advisories, but we'd also like to ensure that all our dependencies are licensed under compatible licenses, so we added a cargo deny check on pull request. This also scans for security advisories, so we can remove the audit action on PRs. But we will keep in daily, because this action opens issues on the repository, which is nice.

Also added a PR template with some common checks to do before signing of a PR.