### PR TITLE
Adds support to generate Hadoop configuration XML

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
 thiserror = "1.0"
+v_htmlescape = "0.13"
 
 [dev-dependencies]
 rstest = "0.11"

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -129,7 +129,7 @@ pub fn wrap_hadoop_xml_snippet<T: AsRef<str>>(snippet: T) -> String {
 #[cfg(test)]
 mod tests {
     use crate::writer::{
-        to_hadoop_xml, to_hadoop_xml_snippet, to_java_properties_string, write_java_properties,
+        to_hadoop_xml_snippet, to_java_properties_string, write_java_properties,
         PropertiesWriterError,
     };
     use std::collections::{BTreeMap, HashMap};
@@ -154,7 +154,6 @@ mod tests {
         assert!(result.contains("ab&amp;"));
         assert!(!result.contains("foo"));
         assert!(result.contains(PROPERTY_2));
-        println!("{}", to_hadoop_xml(&result));
     }
 
     #[test]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -78,7 +78,7 @@ where
     let mut result = String::new();
     for (k, v) in properties {
         let escaped_value = match v {
-            Some(value) => escape(&value),
+            Some(value) => escape(value),
             None => continue,
         };
         let escaped_key = escape(k);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,6 +1,7 @@
 use java_properties::{PropertiesError, PropertiesWriter};
 use std::io::Write;
 use thiserror::Error;
+use v_htmlescape::escape;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum PropertiesWriterError {
@@ -15,7 +16,7 @@ pub enum PropertiesWriterError {
 /// property_1=value_1\n
 /// property_2=value_2\n
 ///
-/// The behavior is based on https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html
+/// The behavior is based on <https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html>
 /// and is adapted to "java.util.Properties" if ambiguous or incomplete.
 pub fn to_java_properties_string<'a, T>(properties: T) -> Result<String, PropertiesWriterError>
 where
@@ -52,19 +53,109 @@ where
     Ok(())
 }
 
+/// Converts properties into a Hadoop configuration XML snippet.
+///
+/// This is missing the wrapping `<configuration>...</configuration>` elements so it can be composed.
+/// Elements for which the value is `None` will be ignored.
+/// Empty values (i.e. `""`) will be returned though.
+/// This method will properly escape all keys and values to be safe to use in XML.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashMap;
+/// use product_config::writer::to_hadoop_xml_snippet;
+/// let mut map = HashMap::new();
+/// map.insert("foo".to_string(), Some("bar".to_string()));
+/// map.insert("baz".to_string(), Some("foo".to_string()));
+/// map.insert("bar".to_string(), None);
+/// let result = to_hadoop_xml_snippet(map.iter());
+/// ```
+pub fn to_hadoop_xml_snippet<'a, T>(properties: T) -> String
+where
+    T: Iterator<Item = (&'a String, &'a Option<String>)>,
+{
+    let mut result = String::new();
+    for (k, v) in properties {
+        let escaped_value = match v {
+            Some(value) => escape(&value),
+            None => continue,
+        };
+        let escaped_key = escape(k);
+        result.push_str(&format!(
+            "  <property>\n    <name>{}</name>\n    <value>{}</value>\n  </property>\n",
+            escaped_key, escaped_value
+        ));
+    }
+    result
+}
+
+/// Converts properties into a Hadoop configuration XML.
+///
+/// This includes the wrapping `<configuration>...</configuration>` elements so it cannot be composed.
+/// If you're looking for a composable version look at [`crate::writer::to_hadoop_xml_snippet`].
+/// Elements for which the value is `None` will be ignored.
+/// Empty values (i.e. `""`) will be returned though.
+/// This method will properly escape all keys and values to be safe to use in XML.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashMap;
+/// use product_config::writer::to_hadoop_xml;
+/// let mut map = HashMap::new();
+/// map.insert("foo".to_string(), Some("bar".to_string()));
+/// map.insert("baz".to_string(), Some("foo".to_string()));
+/// map.insert("bar".to_string(), None);
+/// let result = to_hadoop_xml(map.iter());
+/// ```
+pub fn to_hadoop_xml<'a, T>(properties: T) -> String
+where
+    T: Iterator<Item = (&'a String, &'a Option<String>)>,
+{
+    wrap_hadoop_xml_snippet(to_hadoop_xml_snippet(properties))
+}
+
+/// This wraps a XML snippet with the required XML elements to make a Hadoop XML file.
+///
+/// See [`to_hadoop_xml`] and [`to_hadoop_xml_snippet`].
+pub fn wrap_hadoop_xml_snippet<T: AsRef<str>>(snippet: T) -> String {
+    format!(
+        "<?xml version=\"1.0\"?>\n<configuration>\n{}</configuration>",
+        snippet.as_ref()
+    )
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::writer::{to_java_properties_string, write_java_properties, PropertiesWriterError};
+    use crate::writer::{
+        to_hadoop_xml, to_hadoop_xml_snippet, to_java_properties_string, write_java_properties,
+        PropertiesWriterError,
+    };
     use std::collections::{BTreeMap, HashMap};
 
     const PROPERTY_1: &str = "property";
     const PROPERTY_2: &str = "property2";
-    const VALUE_OK: &str = "abc";
+    const VALUE_OK: &str = "ab&c";
     const VALUE_OK_2: &str = "some_text!()";
     const VALUE_OK_2_ESCAPED: &str = "some_text\\!()";
     const VALUE_URL: &str = "file://this/location/file.abc";
     const VALUE_URL_ESCAPED: &str = "file\\://this/location/file.abc";
     const UTF8_ERROR: &str = "æææ";
+
+    #[test]
+    fn test_xml_snippet() {
+        let mut map = HashMap::new();
+        map.insert(PROPERTY_1.to_string(), Some(VALUE_OK.to_string()));
+        map.insert(PROPERTY_2.to_string(), Some(VALUE_OK_2.to_string()));
+        map.insert("foo".to_string(), None);
+
+        let result = to_hadoop_xml_snippet(map.iter());
+        assert!(result.contains("ab&amp;"));
+        assert!(!result.contains("foo"));
+        assert!(result.contains(PROPERTY_2));
+        println!("{}", to_hadoop_xml(&result));
+    }
 
     #[test]
     fn test_writer_ok() -> Result<(), PropertiesWriterError> {


### PR DESCRIPTION
## Description

As the title says this adds support to generate XML that can be used for all kinds of tools from the Hadoop ecosystem.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
