### PR TITLE
Take file paths as Path rather than str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Changed
+- `ProductConfigManager::from_yaml_file` now takes a `&Path` as well as `&str` ([#43])
+
+[#43]: https://github.com/stackabletech/product-config/pull/43
 
 ## [0.2.0] - 2021-11-05
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,15 @@
+use std::path::PathBuf;
+
 use crate::types::PropertyValueSpec;
 use crate::PropertyName;
 
 #[derive(thiserror::Error, Clone, Debug, PartialOrd, PartialEq)]
 pub enum Error {
     #[error("File not found: {file_name}")]
-    FileNotFound { file_name: String },
+    FileNotFound { file_name: PathBuf },
 
     #[error("Could not parse yaml file - {file}: {reason}")]
-    YamlFileNotParsable { file: String, reason: String },
+    YamlFileNotParsable { file: PathBuf, reason: String },
 
     #[error("Could not parse yaml - {content}: {reason}")]
     YamlNotParsable { content: String, reason: String },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 //! - additional information like web links or descriptions
 //!
 use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
 use std::string::String;
 use std::{fs, str};
 
@@ -86,13 +87,13 @@ impl ProductConfigManager {
     /// # Arguments
     ///
     /// * `file_path` - the path to the YAML file
-    pub fn from_yaml_file(file_path: &str) -> ValidationResult<Self> {
-        let contents = fs::read_to_string(file_path).map_err(|_| error::Error::FileNotFound {
-            file_name: file_path.to_string(),
+    pub fn from_yaml_file(file_path: impl AsRef<Path>) -> ValidationResult<Self> {
+        let contents = fs::read_to_string(&file_path).map_err(|_| error::Error::FileNotFound {
+            file_name: file_path.as_ref().to_path_buf(),
         })?;
 
         Self::from_str(&contents).map_err(|serde_error| error::Error::YamlFileNotParsable {
-            file: file_path.to_string(),
+            file: file_path.as_ref().to_path_buf(),
             reason: serde_error.to_string(),
         })
     }


### PR DESCRIPTION
## Description
This is generally considered more idiomatic, and allows non-UTF-8 paths to be used.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
