### PR TITLE
Replace use of deprecated fn std::array::IntoIter::new(..) with IntoIterator::into_iter(..)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,11 +373,11 @@ mod tests {
     macro_rules! collection {
         // map-like
         ($($k:expr => $v:expr),* $(,)?) => {
-            std::iter::Iterator::collect(std::array::IntoIter::new([$(($k, $v),)*]))
+            std::iter::Iterator::collect(IntoIterator::into_iter([$(($k, $v),)*]))
         };
         // set-like
         ($($v:expr),* $(,)?) => {
-            std::iter::Iterator::collect(std::array::IntoIter::new([$($v,)*]))
+            std::iter::Iterator::collect(IntoIterator::into_iter([$($v,)*]))
         };
     }
 


### PR DESCRIPTION
## Description
Replace use of deprecated fn std::array::IntoIter::new(..) with IntoIterator::into_iter(..)
fixes #54 

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
