### PR TITLE
Replace regex with fancy-regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- replaced `regex` with `fancy-regex` to support look-ahead in unit regexes ([#56])
+
+[#56]: https://github.com/stackabletech/product-config/pull/56
+
 ## [0.3.0] - 2021-12-09
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.4.0-nightly"
 
 [dependencies]
 java-properties = "1.3"
-regex = "1.5"
+fancy-regex = "0.8"
 schemars = "0.8"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/data/test_yamls/validate_iso8601_duration.yaml
+++ b/data/test_yamls/validate_iso8601_duration.yaml
@@ -1,0 +1,37 @@
+version: 0.1.0
+spec:
+  units:
+    - unit: &unitDuration
+        name: "duration"
+        regex: "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+S)?)?$"
+        examples:
+          - "PT300S"
+
+properties:
+  - property: &startupDelay
+      propertyNames:
+        - name: "ENV_STARTUP_DELAY"
+          kind:
+            type: "env"
+        - name: "conf.startup.delay"
+          kind:
+            type: "file"
+            file: "my.config"
+      datatype:
+        type: "string"
+        unit: *unitDuration
+      defaultValues:
+        - fromVersion: "0.5.0"
+          value: "PT30S"
+      recommendedValues:
+        - fromVersion: "0.5.0"
+          toVersion: "0.9.11"
+          value: "PT20S"
+        - fromVersion: "1.0.0"
+          value: "PT30S"
+      roles:
+        - name: "role_1"
+          required: true
+        - name: "role_2"
+          required: false
+      asOfVersion: "0.5.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,6 +89,14 @@ pub enum Error {
     #[error("Invalid regex pattern for unit '{unit}': '{regex}'")]
     InvalidRegexPattern { unit: String, regex: String },
 
+    #[error("lala")]
+    RegexNotEvaluatable {
+        property_name: String,
+        unit: String,
+        regex: String,
+        reason: String,
+    },
+
     #[error("[{property_name}]: unit not provided")]
     UnitNotProvided { property_name: PropertyName },
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,11 +89,12 @@ pub enum Error {
     #[error("Invalid regex pattern for unit '{unit}': '{regex}'")]
     InvalidRegexPattern { unit: String, regex: String },
 
-    #[error("lala")]
-    RegexNotEvaluatable {
+    #[error("The regex for unit '{unit}' ('{regex}') could not be evaluated on property '{property_name}' (value: '{value}'): {reason}.")]
+    RegexNotEvaluable {
         property_name: String,
         unit: String,
         regex: String,
+        value: String,
         reason: String,
     },
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -710,6 +710,28 @@ mod tests {
             "ENV_INTEGER_PORT_MIN_MAX".to_string() => PropertyValidationResult::Valid("1024".to_string()),
         })
     )]
+    #[case::get_iso8601_duration_user_value_invalid(
+        &PropertyNameKind::Env,
+        "role_1",
+        "data/test_yamls/validate_iso8601_duration.yaml",
+        macro_to_hash_map(collection!{
+            "ENV_STARTUP_DELAY".to_string() => Some("invalid".to_string())
+        }),
+        macro_to_get_result(collection!{
+            "ENV_STARTUP_DELAY".to_string() => PropertyValidationResult::Error("invalid".to_string(), Error::DatatypeRegexNotMatching { property_name: "ENV_STARTUP_DELAY".to_string(), value: "invalid".to_string() })
+        })
+    )]
+    #[case::get_iso8601_duration_user_value_invalid(
+        &PropertyNameKind::Env,
+        "role_1",
+        "data/test_yamls/validate_iso8601_duration.yaml",
+        macro_to_hash_map(collection!{
+            "ENV_STARTUP_DELAY".to_string() => Some("PT300S".to_string())
+        }),
+        macro_to_get_result(collection!{
+            "ENV_STARTUP_DELAY".to_string() => PropertyValidationResult::Valid("PT300S".to_string())
+        })
+    )]
     fn test_get(
         #[case] kind: &PropertyNameKind,
         #[case] role: &str,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::{fmt, ops};
 
-use regex::Regex;
+use fancy_regex::Regex;
 use schemars::gen::SchemaGenerator;
 use schemars::schema::Schema;
 use schemars::JsonSchema;
@@ -327,8 +327,8 @@ where
 }
 
 impl ops::Deref for StackableRegex {
-    type Target = regex::Regex;
-    fn deref(&self) -> &regex::Regex {
+    type Target = Regex;
+    fn deref(&self) -> &Regex {
         &self.compiled
     }
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -123,10 +123,11 @@ fn check_datatype_string(
                 }
             }
             Err(e) => {
-                return Err(Error::RegexNotEvaluatable {
+                return Err(Error::RegexNotEvaluable {
                     property_name: name.to_string(),
                     unit: unit.name.to_string(),
                     regex: unit.regex.to_string(),
+                    value: value.to_string(),
                     reason: e.to_string(),
                 })
             }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -113,11 +113,23 @@ fn check_datatype_string(
     check_bound::<usize>(name, len, max, max_bound)?;
 
     if let Some(unit) = unit {
-        if !unit.regex.is_match(value) {
-            return Err(Error::DatatypeRegexNotMatching {
-                property_name: name.to_string(),
-                value: value.to_string(),
-            });
+        match unit.regex.is_match(value) {
+            Ok(is_match) => {
+                if !is_match {
+                    return Err(Error::DatatypeRegexNotMatching {
+                        property_name: name.to_string(),
+                        value: value.to_string(),
+                    });
+                }
+            }
+            Err(e) => {
+                return Err(Error::RegexNotEvaluatable {
+                    property_name: name.to_string(),
+                    unit: unit.name.to_string(),
+                    regex: unit.regex.to_string(),
+                    reason: e.to_string(),
+                })
+            }
         }
     }
 


### PR DESCRIPTION
## Description

I want to use look-ahead in a unit regex, and the `regex` package does not support this. `fancy-regex` is built on top of the `regex` package and supports look-ahead.

This PR replaces `regex` with `fancy-regex`

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
