### PR TITLE
Upgrade java-properties to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/stackabletech/product-config"
 version = "0.4.0"
 
 [dependencies]
-java-properties = "1.3"
+java-properties = "2.0"
 fancy-regex = "0.11"
 schemars = "0.8"
 semver = "1.0"


### PR DESCRIPTION
## Description

This should drop the dependency on encoding (https://github.com/stackabletech/operator-rs/issues/567).

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
