### PR TITLE
chore: Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.0] - 2025-09-23
+
 ## Changed
 
 - Bump `fancy-regex`, `schemars`, `xml` and `rstest` ([#112]).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "product-config"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "fancy-regex",
  "java-properties",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "product-config"
 repository = "https://github.com/stackabletech/product-config"
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies]
 java-properties = "2.0"


### PR DESCRIPTION

## Changed

- Bump `fancy-regex`, `schemars`, `xml` and `rstest` ([#112]).

[#112]: https://github.com/stackabletech/product-config/pull/112